### PR TITLE
Only enable flycheck in clojure buffers with cider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The latter is strongly recommended, so that linting and type errors don't clash 
 auto-documentation.
 
 ~~~.el
-(add-hook 'after-init-hook #'global-flycheck-mode)
+(add-hook 'cider-mode-hook (lambda () (flycheck-mode 1)))
 (eval-after-load 'flycheck
   '(custom-set-variables
    '(flycheck-display-errors-function #'flycheck-pos-tip-error-messages)))


### PR DESCRIPTION
It won't work for clojure buffers where cider-mode isn't on yet anyway.
