### PR TITLE
Don't error when there is no nrepl active

### DIFF
--- a/squiggly-clojure.el
+++ b/squiggly-clojure.el
@@ -102,7 +102,7 @@ Return a list of parsed `flycheck-error' objects."
 Checks for `cider-mode', and a current nREPL connection.
 
 Standard predicate for cider checkers."
-  (let ((connection-buffer (nrepl-current-connection-buffer)))
+  (let ((connection-buffer (nrepl-current-connection-buffer t)))
     (and (bound-and-true-p cider-mode)
          connection-buffer
          (buffer-live-p (get-buffer connection-buffer)))))


### PR DESCRIPTION
This passes `t` to the `no-error` flag, avoiding an error every time flycheck checks if the checker can run if there is no nrepl connection.