### PR TITLE
Fix reference to removed function

### DIFF
--- a/elisp/flycheck-clojure/flycheck-clojure.el
+++ b/elisp/flycheck-clojure/flycheck-clojure.el
@@ -73,7 +73,7 @@ Return a list of parsed `flycheck-error' objects."
 (defun cider-flycheck-eval (input callback)
   "Send the request INPUT and register the CALLBACK as the response handler.
 Uses the tooling session, with no specified namespace."
-  (nrepl-request:eval input callback nil (nrepl-current-tooling-session)))
+  (nrepl-request:eval input callback nil (cider-current-tooling-session)))
 
 (defun flycheck-clojure-may-use-cider-checker ()
   "Determine whether a cider checker may be used.

--- a/elisp/typed-clojure/clojure-typed-doc.el
+++ b/elisp/typed-clojure/clojure-typed-doc.el
@@ -35,7 +35,7 @@
 (defun cider-clojure-typed-eval (input callback)
   "Send the request INPUT and register the CALLBACK as the response handler.
 Uses the tooling session, with no specified namespace."
-  (nrepl-request:eval input callback nil (nrepl-current-tooling-session)))
+  (nrepl-request:eval input callback nil (cider-current-tooling-session)))
 
 
 (defun infer-clojure-types (&optional ns)


### PR DESCRIPTION
nrepl-current-tooling-session has been replaced by
cider-current-tooling-session in the latest version of cider to
accommodate having different tooling session running for clj and cljs at
the same time.