### PR TITLE
Use new cider-jack-in-dependencies variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ like this in it:
 and  `core.typed` requires **clojure 1.7.0**, which is therefore a requirement of squiggly clojure; it is not currently possible to use squiggly clojure without
 the availability of all three linters, even if you aren't using all of them.
 
+If you're using a newer version of cider, the dependency will be automatically
+added to `cider-jack-in-dependencies` unless you specifically disable it by
+setting `flycheck-clojure-inject-dependencies-at-jack-in` to nil.
+
 
 ### Configuration
 

--- a/elisp/flycheck-clojure/flycheck-clojure.el
+++ b/elisp/flycheck-clojure/flycheck-clojure.el
@@ -43,6 +43,14 @@
 (require 'url-parse)
 (eval-when-compile (require 'let-alist))
 
+(defcustom flycheck-clojure-inject-dependencies-at-jack-in t
+  "When nil, do not inject repl dependencies (i.e. the linters/checkers) at `cider-jack-in' time."
+  :group 'flycheck-clojure
+  :type 'boolean)
+
+(defvar flycheck-clojure-dep-version "0.1.5"
+  "Version of `acyclic/squiggly-clojure' compatible with this version of flycheck-clojure.")
+
 ;;;###autoload
 (defun flycheck-clojure-parse-cider-errors (value checker)
   "Parse cider errors from JSON VALUE from CHECKER.
@@ -185,6 +193,13 @@ See URL `https://github.com/clojure-emacs/cider/' and URL
            "(do (require 'squiggly-clojure.core) (squiggly-clojure.core/check-tc '%s))"
            ns)))
 
+(defun flycheck-clojure-inject-jack-in-dependencies ()
+  "Inject the REPL dependencies of flycheck-clojure at `cider-jack-in'.
+If injecting the dependencies is not preferred set `flycheck-clojure-inject-dependencies-at-jack-in' to nil."
+  (when (and flycheck-clojure-inject-dependencies-at-jack-in
+             (boundp 'cider-jack-in-dependencies))
+    (add-to-list 'cider-jack-in-dependencies `("acyclic/squiggly-clojure" ,flycheck-clojure-dep-version))))
+
 ;;;###autoload
 (defun flycheck-clojure-setup ()
   "Setup Flycheck for Clojure."
@@ -193,7 +208,8 @@ See URL `https://github.com/clojure-emacs/cider/' and URL
   (dolist (checker '(clojure-cider-typed
                      clojure-cider-kibit
                      clojure-cider-eastwood))
-    (add-to-list 'flycheck-checkers checker)))
+    (add-to-list 'flycheck-checkers checker))
+  (flycheck-clojure-inject-jack-in-dependencies))
 
 (provide 'flycheck-clojure)
 


### PR DESCRIPTION
Instead of requiring people to modify their `~/.lein/profiles.clj` to
use squiggly-clojure, instead use the new `cider-jack-in-dependencies`
variable to automatically add it when `cider-jack-in` is run.