### PR TITLE
Use `cider-tooling-eval`

### DIFF
--- a/elisp/flycheck-clojure/flycheck-clojure.el
+++ b/elisp/flycheck-clojure/flycheck-clojure.el
@@ -81,7 +81,7 @@ Return a list of parsed `flycheck-error' objects."
 (defun cider-flycheck-eval (input callback)
   "Send the request INPUT and register the CALLBACK as the response handler.
 Uses the tooling session, with no specified namespace."
-  (cider-nrepl-request:eval input callback))
+  (cider-tooling-eval input callback))
 
 (defun flycheck-clojure-may-use-cider-checker ()
   "Determine whether a cider checker may be used.


### PR DESCRIPTION
Instead of using `cider-nrepl-request:eval`, which invokes the spinner
in the REPL, use `cider-tooling-eval`.

The real reason behind this change has nothing to do with the spinner
itself, but when the spinner is spinning, the cider refuses to evaluate
any new code. Which means, that while a buffer is flychecking, I can't
use the repl or re-compile code, using `cider-tooling-eval` let's the
checkers run in the background, only interacting with the user's
workflow when emacs is actually processing the results.