### PR TITLE
Convert (:squiggly env) to datastructure in case it's a string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [environ "1.0.0"]
+                 [environ "1.1.0"]
                  [org.clojure/core.typed "0.3.32" :exclusions [org.clojure/clojure] :classifier "slim"]
                  [org.clojure/data.json "0.2.6"]
                  [jonase/eastwood "0.2.3" :exclusions [org.clojure/clojure]]

--- a/src/squiggly_clojure/core.clj
+++ b/src/squiggly_clojure/core.clj
@@ -4,11 +4,17 @@
             clojure.data.json
             clojure.core.typed
             environ.core
-            ))
+            clojure.edn))
+
+(defn- convert-env-config [config]
+  (if (string? config)
+    (clojure.edn/read-string config)
+    config))
 
 (defn env [ns]
   (or (:squiggly (meta (the-ns ns)))
-      (:squiggly environ.core/env)))
+      (convert-env-config
+       (:squiggly environ.core/env))))
 
 (defn do-lint? [checker ns]
   (and (find-ns ns)


### PR DESCRIPTION
This should close #49. Also, I'm wondering is it worth to bump environ to 1.1.0 here. What do you think?