### PR TITLE
eastwood and boot

### DIFF
--- a/elisp/flycheck-clojure/flycheck-clojure.el
+++ b/elisp/flycheck-clojure/flycheck-clojure.el
@@ -70,7 +70,8 @@ Return a list of parsed `flycheck-error' objects."
                                       (url-filename
                                        (url-generic-parse-url .file))))
                        (filename (if (and parsed-file
-                                          (file-name-absolute-p parsed-file))
+                                          (file-name-absolute-p parsed-file)
+                                          (not (string-prefix-p (expand-file-name "~/.boot/cache") parsed-file)))
                                      parsed-file
                                    (buffer-file-name))))
                   (flycheck-error-new-at .line .column (intern .level) .msg


### PR DESCRIPTION
I'm using boot for a clojure project.
Unfortunately file names reported by the eastwood syntax checker are absolute but located into the boot cache directory(`~/.boot/cache`), so the function `flycheck-clojure-parse-cider-errors` reports the wrong file name. 
This patch fixes this issue for my case, (boot version 2.7.1).